### PR TITLE
[chef apache::php] add a default timezone

### DIFF
--- a/chef/cookbooks/apache/attributes/php.rb
+++ b/chef/cookbooks/apache/attributes/php.rb
@@ -1,1 +1,2 @@
 default[:php][:version] = "php53"
+default[:php][:timezone] = "Europe/Brussels"


### PR DESCRIPTION
There's no default timezone. This sets Europe/Brussels as default timezone in /etc/php5/fpm/conf.d/timezone.ini
