### PR TITLE
Set xdebug.max_nesting_level to a higher value

### DIFF
--- a/chef/cookbooks/apache/attributes/php_xdebug.rb
+++ b/chef/cookbooks/apache/attributes/php_xdebug.rb
@@ -9,3 +9,4 @@ default[:xdebug][:file_link_format] = "txmt://open?url=file://%f&line=%1"
 default[:xdebug][:profiler_enable_trigger] = 0
 default[:xdebug][:profiler_enable] = 0
 default[:xdebug][:profiler_output_dir] = "/tmp/cachegrind"
+default[:xdebug][:max_nesting_level] = 250

--- a/chef/cookbooks/apache/templates/default/xdebug.ini.erb
+++ b/chef/cookbooks/apache/templates/default/xdebug.ini.erb
@@ -2,6 +2,7 @@
 zend_extension=<%= `find /usr -name "xdebug.so" | tr -d "\n"` %>
 xdebug.cli_color = <%= @params['cli_color'] %>
 xdebug.scream = <%= @params['scream'] %>
+xdebug.max_nesting_level = <%= @params['max_nesting_level'] %>
 
 [xdebug-remote-debug]
 xdebug.remote_enable = <%= @params['remote_enable'] %>


### PR DESCRIPTION
Set xdebug.max_nesting_level to 250 in php.ini to stop Xdebug's infinite recursion
protection erroneously throwing a fatal error
