### PR TITLE
Apache: vhost: fix template file source.

### DIFF
--- a/chef/cookbooks/apache/recipes/passenger.rb
+++ b/chef/cookbooks/apache/recipes/passenger.rb
@@ -52,7 +52,10 @@ gem_package "bundler" do
   action :install
 end
 
-cookbook_file "/etc/apache2/sites-available/default" do
-  source "rack_vhost.conf"
+template "/etc/apache2/sites-available/default" do
+  source "rack_vhost.conf.erb"
+  mode "0644"
+  owner "root"
+  action :create
   notifies :restart, "service[apache2]"
 end


### PR DESCRIPTION
The template file was listed as an actual file whilst it is actually a
template file. This should be reflected as such.

As you can see [here](https://github.com/openminds/sneakers/tree/master/chef/cookbooks/apache/files/default) there is no rack_vhost.conf file, this file 
is [here](https://github.com/openminds/sneakers/blob/master/chef/cookbooks/apache/templates/default/rack_vhost.conf.erb) (although with a slightly different name).

I noticed this when I used the following settings:

``` blog:
  app_directory: "/Users/jelmersnoeck/Projects/blog"
  type: "ruby193"
  http_port: 8040
  memory: 1024
```

I got the following error:

```
[2013-06-03T21:07:44+02:00] FATAL: Chef::Exceptions::FileNotFound: cookbook_file[/etc/apache2/sites-available/default] (apache::passenger line 55) had an error: Chef::Exceptions::FileNotFound: Cookbook 'apache' (0.1.0) does not contain a file at any of these locations:
  files/debian-6.0.7/rack_vhost.conf.erb
  files/debian/rack_vhost.conf.erb
  files/default/rack_vhost.conf.erb
```
