### PR TITLE
fixed pinning for dotdeb

### DIFF
--- a/chef/cookbooks/apache/files/default/dotdeb_php_pinning
+++ b/chef/cookbooks/apache/files/default/dotdeb_php_pinning
@@ -1,7 +1,0 @@
-Package: *
-Pin: origin packages.dotdeb.org
-Pin-Priority: 100
-
-Package: php5-cgi php5-cli php5-common php5-fpm php5-curl php5-dev php5-gd php5-imagick php5-imap php5-mcrypt php5-memcache php5-memcached php5-mysql php5-xmlrpc libapache2-mod-php5 php5-apc php5-http php5-imagick php5-redis php5-geoip php5-intl php5-ffmpeg php5-sybase php5-xcache php5-xdebug
-Pin: origin packages.dotdeb.org
-Pin-Priority: 600

--- a/chef/cookbooks/apache/files/default/tests/minitest/php_test.rb
+++ b/chef/cookbooks/apache/files/default/tests/minitest/php_test.rb
@@ -3,6 +3,8 @@ class TestPhp < MiniTest::Chef::TestCase
     case node[:php][:version]
     when "php54"
       assert File.exists?("/etc/apt/sources.list.d/dotdeb-php54.list")
+      assert File.exists?("/etc/apt/sources.list.d/dotdeb.list")
+      assert File.exists?("/etc/apt/preferences.d/dotdeb-php54.list")
     else
       assert File.exists?("/etc/apt/sources.list.d/dotdeb.list")
     end

--- a/chef/cookbooks/apache/recipes/php.rb
+++ b/chef/cookbooks/apache/recipes/php.rb
@@ -14,6 +14,15 @@ when "php54"
     key "http://www.dotdeb.org/dotdeb.gpg"
     action :add
   end
+  
+    apt_repository "dotdeb" do
+      uri "http://packages.dotdeb.org"
+      distribution node['lsb']['codename']
+      components ["all"]
+      key "http://www.dotdeb.org/dotdeb.gpg"
+      action :add
+  end
+  
 when "php53"
   apt_repository "dotdeb" do
     uri "http://packages.dotdeb.org"
@@ -26,12 +35,13 @@ else
   raise "Unknown PHP version type. Was: #{node[:php][:version]}"
 end
 
-cookbook_file "/etc/apt/preferences.d/dotdeb_php_pinning" do
-  source "dotdeb_php_pinning"
-  mode "0644"
+template "/etc/apt/preferences.d/dotdeb_php_pinning" do
+  source "dotdeb_php_pinning.erb"
   owner "root"
+  mode "0644"
   action :create
 end
+
 
 %w[php5-cli php5-common php5-fpm php5-curl php5-dev php5-gd php5-imagick php5-imap php5-mcrypt php5-mysql php5-xmlrpc php-pear php5-intl php5-apc].each do |pkg|
   package pkg

--- a/chef/cookbooks/apache/templates/default/dotdeb_php_pinning.erb
+++ b/chef/cookbooks/apache/templates/default/dotdeb_php_pinning.erb
@@ -1,0 +1,25 @@
+Package: *
+Pin: origin packages.dotdeb.org
+Pin-Priority: 100
+
+<%
+case node[:php][:version]
+when "php54"
+%>
+
+Package: php5-cgi php5-cli php5-common php5-fpm php5-curl php5-dev php5-gd php5-imagick php5-imap php5-mcrypt php5-memcache php5-memcached php5-mysql php5-xmlrpc libapache2-mod-php5 php5-apc php5-http php5-imagick php5-redis php5-geoip php5-intl php5-ffmpeg php5-sybase php5-xcache php5-xdebug
+Pin: release o=packages.dotdeb.org,a=oldstable,n=squeeze-php54,l=packages.dotdeb.org,c=all
+Pin-Priority: 600
+
+<%
+when "php53"
+%>
+Package: php5-cgi php5-cli php5-common php5-fpm php5-curl php5-dev php5-gd php5-imagick php5-imap php5-mcrypt php5-memcache php5-memcached php5-mysql php5-xmlrpc libapache2-mod-php5 php5-apc php5-http php5-imagick php5-redis php5-geoip php5-intl php5-ffmpeg php5-sybase php5-xcache php5-xdebug
+Pin: origin packages.dotdeb.org
+Pin-Priority: 600
+  
+<%  
+else
+  raise "Unknown PHP version type. Was: #{node[:php][:version]}"
+end
+%>


### PR DESCRIPTION
Fixed pinning for dotdeb when you use php54. libmemached10 comes from the packages.dotdeb.org repo.
