### PR TITLE
fix php test: check if dotdeb_php_pinning file exists

### DIFF
--- a/chef/cookbooks/apache/files/default/tests/minitest/php_test.rb
+++ b/chef/cookbooks/apache/files/default/tests/minitest/php_test.rb
@@ -4,7 +4,7 @@ class TestPhp < MiniTest::Chef::TestCase
     when "php54"
       assert File.exists?("/etc/apt/sources.list.d/dotdeb-php54.list")
       assert File.exists?("/etc/apt/sources.list.d/dotdeb.list")
-      assert File.exists?("/etc/apt/preferences.d/dotdeb-php54.list")
+      assert File.exists?("/etc/apt/preferences.d/dotdeb_php_pinning")
     else
       assert File.exists?("/etc/apt/sources.list.d/dotdeb.list")
     end


### PR DESCRIPTION
There was a wrong file check in the php minitest wen using version 'php54'
