### PR TITLE
[nginx] Fixes nxing restart issue for Windows

### DIFF
--- a/chef/cookbooks/nginx/recipes/configuration.rb
+++ b/chef/cookbooks/nginx/recipes/configuration.rb
@@ -7,21 +7,19 @@ cookbook_file '/etc/nginx/mime.types' do
   source 'mime.types'
 end
 
-cookbook_file '/etc/nginx/nginx.conf' do
-  source 'nginx.conf'
-  notifies :restart, 'service[nginx]'
-end
-
 cookbook_file '/etc/init.d/nginx' do
   source 'init.d-nginx'
   owner 'root'
   group 'root'
   mode '0755'
-  notifies :run, 'execute[Fix windows <CR>]'
-  notifies :restart, 'service[nginx]'
+  # notifies :run, 'execute[Fix windows <CR>]'
 end
 
 execute 'Fix windows <CR>' do
   command "perl -i -pe's/\r$//;' /etc/init.d/nginx"
-  action :nothing
+end
+
+cookbook_file '/etc/nginx/nginx.conf' do
+  source 'nginx.conf'
+  notifies :restart, 'service[nginx]'
 end


### PR DESCRIPTION
init.d/nginx was not yet created when init.d/nginx restart was called.
